### PR TITLE
Settings via meta fields

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/edit-post';
+import { ToggleControl } from '@wordpress/components';
+
+const AppShellSettingPanel = ({ meta, onMetaFieldChange }) => (
+	<PluginDocumentSettingPanel name="popup-settings-panel" title={__('App Shell Settings')}>
+		<ToggleControl
+			label={__('Fixed to bottom')}
+			checked={Boolean(meta.is_fixed)}
+			onChange={value => onMetaFieldChange('is_fixed', value)}
+		/>
+	</PluginDocumentSettingPanel>
+);
+
+const AppShellSettingPanelWithData = compose([
+	withSelect(select => {
+		const { getEditedPostAttribute } = select('core/editor');
+		return { meta: getEditedPostAttribute('meta') || {} };
+	}),
+	withDispatch(dispatch => {
+		return {
+			onMetaFieldChange: (key, value) => {
+				dispatch('core/editor').editPost({ meta: { [key]: value } });
+			},
+		};
+	}),
+])(AppShellSettingPanel);
+
+registerPlugin('newspack-app-shell', {
+	render: AppShellSettingPanelWithData,
+	icon: null,
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = getBaseWebpackConfig(
 	{
 		mode: process.env.NODE_ENV || 'production',
 		entry: {
+			editor: './src/editor/index.js',
 			client: './src/client/index.js',
 		},
 	}


### PR DESCRIPTION
This will introduce a setting to affix the `.newspack-app-shell-wrapper` element to the bottom of the viewport.

**Problem**: the meta field is not saved for some reason