### PR TITLE
Settings for fixing layout to viewport

### DIFF
--- a/includes/class-newspack-app-shell.php
+++ b/includes/class-newspack-app-shell.php
@@ -133,12 +133,12 @@ final class Newspack_App_Shell {
 		);
 		if ( $id ) {
 			?>
-			<div class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+			<span class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
 				<?php
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo get_the_content( null, false, $id );
 				?>
-			</div>
+			</span>
 			<?php
 		}
 	}

--- a/includes/class-newspack-app-shell.php
+++ b/includes/class-newspack-app-shell.php
@@ -37,9 +37,11 @@ final class Newspack_App_Shell {
 	 * Register WP hooks.
 	 */
 	public function __construct() {
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_script' ) );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts_and_style' ) );
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'add_menu_item' ) );
 		add_action( 'init', array( __CLASS__, 'register_cpt' ) );
+		add_action( 'init', array( __CLASS__, 'register_meta' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'insert_persistent_content' ) );
 	}
 
@@ -51,9 +53,37 @@ final class Newspack_App_Shell {
 			'public'       => false,
 			'show_ui'      => true,
 			'show_in_rest' => true,
-			'supports'     => array( 'editor' ),
+			'supports'     => array( 'editor', 'custom-fields' ),
 		);
 		\register_post_type( self::NEWSPACK_APP_SHELL_CPT, $cpt_args );
+	}
+
+	/**
+	 * Register meta fields for the CPT.
+	 */
+	public static function register_meta() {
+		\register_meta(
+			'post',
+			'is_bottom_fixed',
+			array(
+				'object_subtype' => self::NEWSPACK_APP_SHELL_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'boolean',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			)
+		);
+		\register_meta(
+			'post',
+			'is_top_fixed',
+			array(
+				'object_subtype' => self::NEWSPACK_APP_SHELL_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'boolean',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			)
+		);
 	}
 
 	/**
@@ -93,17 +123,30 @@ final class Newspack_App_Shell {
 	 * Insert the persistent content
 	 */
 	public static function insert_persistent_content() {
-		$id = self::post_id();
+		$id              = self::post_id();
+		$is_top_fixed    = get_post_meta( $id, 'is_top_fixed', true );
+		$is_bottom_fixed = get_post_meta( $id, 'is_bottom_fixed', true );
+		$classes         = array(
+			'newspack-app-shell-wrapper',
+			$is_bottom_fixed ? 'newspack-app-shell-wrapper--bottom-fixed' : '',
+			$is_top_fixed ? 'newspack-app-shell-wrapper--top-fixed' : '',
+		);
 		if ( $id ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo get_the_content( null, false, $id );
+			?>
+			<div class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+				<?php
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo get_the_content( null, false, $id );
+				?>
+			</div>
+			<?php
 		}
 	}
 
 	/**
 	 * Load client JS script
 	 */
-	public static function enqueue_script() {
+	public static function enqueue_scripts_and_style() {
 		wp_register_script(
 			'newspack-app-shell',
 			plugins_url( '/newspack-app-shell' ) . '/dist/client.js',
@@ -122,6 +165,40 @@ final class Newspack_App_Shell {
 			sprintf( 'var APP_SHELL_WP_DATA = %s;', wp_json_encode( $exports ) ),
 			'before'
 		);
+
+		self::enqueue_style();
+	}
+
+	/**
+	 * Load client CSS
+	 */
+	public static function enqueue_style() {
+		wp_register_style(
+			'newspack-app-shell-client',
+			plugins_url( '/newspack-app-shell' ) . '/dist/client.css',
+			null,
+			filemtime( dirname( NEWSPACK_APP_SHELL_PLUGIN_FILE ) . '/dist/client.css' )
+		);
+		wp_enqueue_style( 'newspack-app-shell-client' );
+	}
+
+	/**
+	 * Load editor JS script
+	 */
+	public static function enqueue_block_editor_assets() {
+		$screen = get_current_screen();
+		if ( self::NEWSPACK_APP_SHELL_CPT !== $screen->post_type ) {
+			return;
+		}
+
+		wp_register_script(
+			'newspack-app-shell-editor',
+			plugins_url( '/newspack-app-shell' ) . '/dist/editor.js',
+			array(),
+			filemtime( dirname( NEWSPACK_APP_SHELL_PLUGIN_FILE ) . '/dist/editor.js' ),
+			true
+		);
+		wp_enqueue_script( 'newspack-app-shell-editor' );
 	}
 }
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,12 +1,17 @@
 // based on https://github.com/ampproject/amp-wp/pull/1519
 
 /**
+ * External dependencies
+ */
+// polyfill, as there is no support in IE11
+import 'element-closest';
+
+/**
  * Internal dependencies
  */
 import { fetchDocument } from './fetch';
 import { hashDOMNode, compareDOMNodeCollections, fireEvent } from './utils';
-// polyfill, as there is no support in IE11
-import 'element-closest';
+import './style.scss';
 
 /**
  * Attach event handlers to the document.

--- a/src/client/style.scss
+++ b/src/client/style.scss
@@ -1,0 +1,23 @@
+.newspack-app-shell-wrapper {
+	width: 100%;
+	&--top-fixed,
+	&--bottom-fixed {
+		position: fixed;
+		z-index: 999;
+		left: 0;
+	}
+	&--top-fixed {
+		top: 0;
+	}
+	&--bottom-fixed {
+		bottom: 0;
+	}
+}
+
+body.admin-bar {
+	.newspack-app-shell-wrapper {
+		&--top-fixed {
+			padding-top: 32px;
+		}
+	}
+}

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/edit-post';
+import { ToggleControl } from '@wordpress/components';
+
+const AppShellSettingPanel = ({ meta, onMetaFieldChange }) => (
+	<PluginDocumentSettingPanel name="popup-settings-panel" title={__('App Shell Settings')}>
+		<ToggleControl
+			label={__('Fixed to top')}
+			checked={Boolean(meta.is_top_fixed)}
+			onChange={value => {
+				onMetaFieldChange('is_top_fixed', value);
+				if (meta.is_bottom_fixed) {
+					onMetaFieldChange('is_bottom_fixed', false);
+				}
+			}}
+		/>
+		<ToggleControl
+			label={__('Fixed to bottom')}
+			checked={Boolean(meta.is_bottom_fixed)}
+			onChange={value => {
+				onMetaFieldChange('is_bottom_fixed', value);
+				if (meta.is_top_fixed) {
+					onMetaFieldChange('is_top_fixed', false);
+				}
+			}}
+		/>
+	</PluginDocumentSettingPanel>
+);
+
+const AppShellSettingPanelWithData = compose([
+	withSelect(select => {
+		const { getEditedPostAttribute } = select('core/editor');
+		return { meta: getEditedPostAttribute('meta') || {} };
+	}),
+	withDispatch(dispatch => {
+		return {
+			onMetaFieldChange: (key, value) => {
+				dispatch('core/editor').editPost({ meta: { [key]: value } });
+			},
+		};
+	}),
+])(AppShellSettingPanel);
+
+registerPlugin('newspack-app-shell', {
+	render: AppShellSettingPanelWithData,
+	icon: null,
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = getBaseWebpackConfig(
 	{
 		mode: process.env.NODE_ENV || 'production',
 		entry: {
+			editor: './src/editor/index.js',
 			client: './src/client/index.js',
 		},
 	}


### PR DESCRIPTION
## What it does

Introduces settings that allow to fix the content of the persistent element to top or bottom of the viewport.

## How to test

1. (pull & rebuild)
1. create the persistent element ("Add/Edit Persistent element" in the left admin menu)
    1. insert and audio block and provide [this amazing mp3 by a mysterious online artist called Chopin](http://www.mp3classicalmusic.net/48Music/Chopin48/Ballata1.mp3) as source
1. Publish/Update the changes
1. visit the site
1. observe that the audio player is on the bottom of the page (not fixed to viewport). Click play
1. on navigation, the music should still play
1. now edit the persistent element - set it to be fixed to top/bottom and observe that it's now fixed to the viewport 
1. as before, on navigation, the music should still play