### PR TITLE
Initialise Jetpack lazy loading images on navigation

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -170,6 +170,9 @@ function loadUrl(url, options = {}) {
 
 		document.body.classList.remove('newspack-app-shell-transitioning');
 
+		// Fire Jetpack's lazy load images initalisation
+		document.body.dispatchEvent(new Event('jetpack-lazy-images-load'))
+
 		fireEvent('newspack-app-shell-ready');
 	});
 }


### PR DESCRIPTION
## How to test

1. (pull & build)
1. Enable [Jetpack's lazy load images feature](https://jetpack.com/support/lazy-images/)
1. Navigate the site
1. Observe that the images are visible after page rerender

Closes #9 