### PR TITLE
Run page scripts

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -121,11 +121,24 @@ function loadUrl(url, options = {}) {
 
 	fetchDocument(url).then(function(doc) {
 		// get HTML content
-		const pageHTML = doc.getElementById(CONTENT_ELEMENT_ID).innerHTML;
+		const pageContent = doc.getElementById(CONTENT_ELEMENT_ID);
+		const pageHTML = pageContent.innerHTML;
 
 		// replace the #page contents
 		const container = document.getElementById(CONTENT_ELEMENT_ID);
 		container.innerHTML = pageHTML;
+
+		// Run any scripts that were in the page contents - scripts injected
+		// via setting innerHTML are not executed.
+		[...pageContent.querySelectorAll("script")].forEach( oldScript => {
+			const newScript = document.createElement("script");
+			[...oldScript.attributes]
+				.forEach( attr => newScript.setAttribute(attr.name, attr.value) );
+			newScript.appendChild(document.createTextNode(oldScript.innerHTML));
+			// Note: for some reason, replaceChild on parent element did not
+			// result in executing the script.
+			document.body.appendChild(newScript);
+		});
 
 		// diff head and update all elements
 		const headDiff = compareDOMNodeCollections(


### PR DESCRIPTION
Any `script` elements in `#page` contents were not run, because setting an element's `innerHTML` does not execute any scripts contained in this inner HTML.
The solution is to look for the scripts in the newly created contents and append them to the body.

### How to test

1. create a post with an inline `script` (e.g. `<script>alert('hi!')</script>`)
1. navigate to this post from somewhere else (so that the contents are fetched via XHR)
1. observe that the script is executed