### PR TITLE
Hide CPT in admin new post menu

### DIFF
--- a/includes/class-newspack-app-shell.php
+++ b/includes/class-newspack-app-shell.php
@@ -49,6 +49,7 @@ final class Newspack_App_Shell {
 	public static function register_cpt() {
 		$cpt_args = array(
 			'public'       => false,
+			'show_in_menu' => false,
 			'show_ui'      => true,
 			'show_in_rest' => true,
 			'supports'     => array( 'editor' ),


### PR DESCRIPTION
This hides the post in the "+ New" menu in admin bar, to prevent this:

![image](https://user-images.githubusercontent.com/7383192/73926537-14f1a680-48d0-11ea-9a42-e184b979002a.png)

Closes #13 