### PR TITLE
Enqueue scripts only if persistent element is present

### DIFF
--- a/includes/class-newspack-app-shell.php
+++ b/includes/class-newspack-app-shell.php
@@ -104,6 +104,10 @@ final class Newspack_App_Shell {
 	 * Load client JS script
 	 */
 	public static function enqueue_script() {
+		if ( ! self::post_id() ) {
+			// No persistent element set, bail.
+			return;
+		}
 		wp_register_script(
 			'newspack-app-shell',
 			plugins_url( '/newspack-app-shell' ) . '/dist/client.js',


### PR DESCRIPTION
## What it does

Prevents scripts from being loaded if no persistent element is present.

Closes #5 

## How to test

1. create the persistent element
1. visit the front-end - `client.js` script should be loaded and the App Shell navigation active
1. trash the persistent element post
1. visit the front-end - `client.js` script should not be loaded, navigation should reload the page like on a plain old website

