### PR TITLE
CI: include zip file in the release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -30,7 +30,7 @@ module.exports = {
 			{
 				assets: [
 					{
-						path: './assets/release/newspack-app-shell.zip',
+						path: './release/newspack-app-shell.zip',
 						label: 'newspack-app-shell.zip',
 					},
 				],


### PR DESCRIPTION
Small fix to CI config that ensures the zip plugin file is included in the release.