### PR TITLE
Fix - release files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,8 @@ jobs:
     steps:
       - checkout_code
       - run:
-          name: Build release
-          command: npm run release
-      - run:
           name: Release new version
-          command: npm run semantic-release
+          command: npm run release
 
 workflows:
   version: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -16288,9 +16288,9 @@
       }
     },
     "semantic-release-version-bump": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-version-bump/-/semantic-release-version-bump-1.1.0.tgz",
-      "integrity": "sha512-EPJ+3fhE8UFZPatPgdKdeItqFIsDlAXw3ZCuMv82MhqFe5/cU/50lKXIFR5y/kfdM5pUBDFV8cHy4222LA0VJg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/semantic-release-version-bump/-/semantic-release-version-bump-1.3.0.tgz",
+      "integrity": "sha512-K0/PvQbFAgCw1p73MlF11jDLnc5rbXUj2PVywVtGXGZuU6rwq5quJ7R8SrPBDrAOtcmtJVsIuDctha9t75e2SQ==",
       "dev": true,
       "requires": {
         "glob": "^7.1.6"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "NODE_ENV=development calypso-build --watch",
     "start": "npm run dev",
     "clean": "rm -rf dist release",
-    "release": "mkdir -p release && zip -r release/newspack-app-shell.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store"
+    "release:archive": "mkdir -p release && zip -r release/newspack-app-shell.zip . -x node_modules/\\* vendor/\\* src/\\* .git/\\* .github/\\* .gitignore .DS_Store",
+    "release": "npm run build && npm run release:archive"
   },
   "keywords": [],
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,13 @@
   "author": "Automattic",
   "scripts": {
     "cm": "git-cz",
-    "semantic-release": "semantic-release",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "calypso-build",
     "dev": "NODE_ENV=development calypso-build --watch",
     "start": "npm run dev",
     "clean": "rm -rf dist release",
     "release:archive": "mkdir -p release && zip -r release/newspack-app-shell.zip . -x node_modules/\\* vendor/\\* src/\\* .git/\\* .github/\\* .gitignore .DS_Store",
-    "release": "npm run build && npm run release:archive"
+    "release": "npm run build && npm run semantic-release"
   },
   "keywords": [],
   "license": "ISC",
@@ -30,7 +29,7 @@
     "commitizen": "^4.0.3",
     "cz-conventional-changelog": "^3.1.0",
     "semantic-release": "^17.0.2",
-    "semantic-release-version-bump": "^1.1.0"
+    "semantic-release-version-bump": "^1.3.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Automattic",
   "scripts": {
     "cm": "git-cz",
+    "semantic-release": "semantic-release",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "calypso-build",
     "dev": "NODE_ENV=development calypso-build --watch",

--- a/release.config.js
+++ b/release.config.js
@@ -7,6 +7,7 @@ module.exports = {
 			'semantic-release-version-bump',
 			{
 				files: 'newspack-app-shell.php',
+				callback: 'npm run release:archive',
 			},
 		],
 		{


### PR DESCRIPTION
Two issues with automated releases, which this PR fixes:
1. JS files were _not compiled_ before release, so they were not included in the release zip archive
1. the archive was created _before_ the version was bumped in plugin files, so the distribution files in the zip contained the old version