### PR TITLE
Fix wrapper bug; update xwp/wp-dev-lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
   "require": {
     "composer/installers": "^1.7",
     "brainmaestro/composer-git-hooks": "^2.8",
-    "xwp/wp-dev-lib": "^1.3"
+    "xwp/wp-dev-lib": "^1.5.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2223f9a4248352a183630d84dd29a03",
+    "content-hash": "e92006735383174d6a22c0ab3b23dfe0",
     "packages": [
         {
             "name": "brainmaestro/composer-git-hooks",
@@ -499,16 +499,16 @@
         },
         {
             "name": "xwp/wp-dev-lib",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/xwp/wp-dev-lib.git",
-                "reference": "86cc5e69b072804c066d10e9008d1576e26aa3cf"
+                "reference": "3e3ced3fdc5c47bbb59cde2f693ce115f2865f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/86cc5e69b072804c066d10e9008d1576e26aa3cf",
-                "reference": "86cc5e69b072804c066d10e9008d1576e26aa3cf",
+                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/3e3ced3fdc5c47bbb59cde2f693ce115f2865f82",
+                "reference": "3e3ced3fdc5c47bbb59cde2f693ce115f2865f82",
                 "shasum": ""
             },
             "type": "library",
@@ -533,7 +533,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2020-01-09T12:33:32+00:00"
+            "time": "2020-02-10T09:35:25+00:00"
         }
     ],
     "packages-dev": [

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -163,6 +163,7 @@ function handleClick( event ) {
 }
 
 const CONTENT_ELEMENT_ID = 'page';
+const NEWSPACK_APP_SHELL_WRAPPER_CLASSNAME = 'newspack-app-shell-wrapper';
 
 /**
  * Fetches HTML document by URL, then replaces the perinent DOM elements
@@ -207,7 +208,9 @@ function loadUrl( url, options = {} ) {
 		headDiff.toAdd.map( el => document.head.appendChild( el ) );
 
 		// diff body, omitting the #page contents
-		const canChangeBodyEl = el => el.id !== CONTENT_ELEMENT_ID;
+		const canChangeBodyEl = el =>
+			el.id !== CONTENT_ELEMENT_ID &&
+			! el.classList.contains( NEWSPACK_APP_SHELL_WRAPPER_CLASSNAME );
 
 		const bodyDiff = compareDOMNodeCollections(
 			document.querySelectorAll( 'body > *' ),


### PR DESCRIPTION
Two small changes:

1. Update `xwp/wp-dev-lib` so that prettier is handled in pre-commit linting hook
1. Prevent the persistent element from being replaced on navigation. No idea why this has not surfaced before :O 

## How to test

The basic functionality should work as expected